### PR TITLE
Add Partners section

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,4 +1,4 @@
-import { Encryption } from "@/components/main/encryption";
+import { Partners } from "@/components/main/partners";
 import { Hero } from "@/components/main/hero";
 import { Projects } from "@/components/main/projects";
 import { Features } from "@/components/main/features";
@@ -10,7 +10,7 @@ export default function Home() {
       <div className="flex flex-col gap-20">
         <Hero />
         <Skills />
-        <Encryption />
+        <Partners />
         <Features />
         <Projects />
       </div>

--- a/components/main/partners.tsx
+++ b/components/main/partners.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import Image from "next/image";
+import Link from "next/link";
+
+import { PARTNERS } from "@/constants";
+
+export const Partners = () => {
+  return (
+    <section
+      id="partners"
+      className="relative flex flex-col items-center justify-center min-h-screen w-full px-4 py-20"
+    >
+      <h1 className="text-[40px] font-semibold text-transparent bg-clip-text bg-gradient-to-r from-purple-500 to-cyan-500 mb-12 text-center">
+        Partners
+      </h1>
+
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-8 w-full max-w-4xl">
+        {PARTNERS.map((partner) => (
+          <Link
+            key={partner.name}
+            href={partner.link}
+            target="_blank"
+            rel="noreferrer noopener"
+            className="flex flex-col items-center border border-[#7042f88b] rounded-lg p-6 bg-[#030014] bg-opacity-90"
+          >
+            <Image
+              src={partner.logo}
+              alt={partner.name}
+              width={100}
+              height={100}
+              className="mb-4"
+            />
+            <p className="text-white text-lg">{partner.name}</p>
+          </Link>
+        ))}
+      </div>
+    </section>
+  );
+};

--- a/constants/index.ts
+++ b/constants/index.ts
@@ -386,3 +386,21 @@ export const FEATURES = [
       "Expert guidance to leverage the cloud for security and scale.",
   },
 ] as const;
+
+export const PARTNERS = [
+  {
+    name: "Partner One",
+    logo: "/logo.png",
+    link: "https://example.com",
+  },
+  {
+    name: "Partner Two",
+    logo: "/logo1.png",
+    link: "https://example.com",
+  },
+  {
+    name: "Partner Three",
+    logo: "/iconS.png",
+    link: "https://example.com",
+  },
+] as const;


### PR DESCRIPTION
## Summary
- create `Partners` component to showcase partners
- add `PARTNERS` constant with sample data
- display Partners section on homepage instead of Encryption

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch font `Inter` due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6864da8bc1bc8324888e2a7a5ef5a5e2