### PR TITLE
Improve contact page layout and animation

### DIFF
--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -1,13 +1,18 @@
+"use client";
+import { useState } from "react";
 import { ContactAnimation } from "@/components/main/contact-animation";
 import { ContactForm } from "@/components/main/contact-form";
 import { StarsCanvas } from "@/components/main/star-background";
 
 export default function ContactPage() {
+  const [name, setName] = useState("John Doe");
   return (
     <main className="relative flex min-h-screen items-center justify-center">
       <StarsCanvas />
-      <ContactAnimation />
-      <ContactForm />
+      <div className="relative z-10 flex flex-col gap-10 md:flex-row md:items-center">
+        <ContactAnimation text={name} />
+        <ContactForm onNameChange={setName} />
+      </div>
     </main>
   );
 }

--- a/components/main/contact-animation.tsx
+++ b/components/main/contact-animation.tsx
@@ -4,11 +4,16 @@ import { useEffect, useRef } from "react";
 import * as THREE from "three";
 import { gsap } from "gsap";
 
-export const ContactAnimation = () => {
+interface ContactAnimationProps {
+  text?: string;
+}
+
+export const ContactAnimation = ({ text }: ContactAnimationProps) => {
   const containerRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
   const buttonRef = useRef<HTMLButtonElement>(null);
-
+  const morphRef = useRef<(t: string) => void>();
+  const initialText = useRef(text);
   useEffect(() => {
     let scene: THREE.Scene;
     let camera: THREE.PerspectiveCamera;
@@ -151,6 +156,8 @@ export const ContactAnimation = () => {
       setTimeout(() => morphToCircle(), 4000);
     }
 
+    morphRef.current = morphToText;
+
     function morphToCircle() {
       currentState = "sphere";
       const positions = particles.geometry.attributes.position.array as Float32Array;
@@ -236,6 +243,7 @@ export const ContactAnimation = () => {
 
     createParticles();
     animate();
+    if (initialText.current) morphToText(initialText.current);
 
     const handleResize = () => {
       if (!container) return;
@@ -266,6 +274,12 @@ export const ContactAnimation = () => {
       container.removeChild(renderer.domElement);
     };
   }, []);
+
+  useEffect(() => {
+    if (text && morphRef.current) {
+      morphRef.current(text);
+    }
+  }, [text]);
 
   return (
     <div ref={containerRef} className="absolute inset-0 -z-10">

--- a/components/main/contact-form.tsx
+++ b/components/main/contact-form.tsx
@@ -1,13 +1,26 @@
 "use client";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
-export const ContactForm = () => {
+interface ContactFormProps {
+  onNameChange?: (name: string) => void;
+}
+
+export const ContactForm = ({ onNameChange }: ContactFormProps) => {
   const [form, setForm] = useState({ name: "", email: "", message: "" });
+
+  useEffect(() => {
+    if (onNameChange) {
+      onNameChange("John Doe");
+    }
+  }, [onNameChange]);
 
   const handleChange = (
     e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
   ) => {
     setForm({ ...form, [e.target.name]: e.target.value });
+    if (e.target.name === "name" && onNameChange) {
+      onNameChange(e.target.value);
+    }
   };
 
   const handleSubmit = (e: React.FormEvent) => {


### PR DESCRIPTION
## Summary
- show contact form and particle animation side by side
- make contact animation accept text prop
- connect animation to form's name field and start with placeholder text

## Testing
- `npm run lint`
- `npm run build` *(fails: NextFontError when fetching fonts)*

------
https://chatgpt.com/codex/tasks/task_e_6864efe4761483249678b7aa08083dc9