### PR TITLE
Update contact layout and morph behavior

### DIFF
--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -10,11 +10,11 @@ export default function ContactPage() {
   return (
     <main className="relative w-full min-h-screen overflow-hidden">
       <StarsCanvas />
-      <div className="relative z-10 flex flex-col h-screen max-w-4xl mx-auto px-4">
-        <div className="flex flex-grow items-center justify-center min-h-[50vh]">
+      <div className="relative z-10 flex flex-col md:flex-row h-screen max-w-4xl mx-auto px-4">
+        <div className="flex flex-1 items-center justify-center">
           <ContactAnimation text={name} />
         </div>
-        <div className="flex flex-grow items-center justify-center min-h-[50vh]">
+        <div className="flex flex-1 items-center justify-center">
           <ContactForm onNameChange={setName} />
         </div>
       </div>

--- a/components/main/contact-animation.tsx
+++ b/components/main/contact-animation.tsx
@@ -10,8 +10,6 @@ interface ContactAnimationProps {
 
 export const ContactAnimation = ({ text }: ContactAnimationProps) => {
   const containerRef = useRef<HTMLDivElement>(null);
-  const inputRef = useRef<HTMLInputElement>(null);
-  const buttonRef = useRef<HTMLButtonElement>(null);
   const morphRef = useRef<(t: string) => void>();
   const initialText = useRef(text);
   useEffect(() => {
@@ -253,23 +251,8 @@ export const ContactAnimation = ({ text }: ContactAnimationProps) => {
     };
     window.addEventListener("resize", handleResize);
 
-    const input = inputRef.current;
-    const button = buttonRef.current;
-
-    const handleClick = () => {
-      const text = input?.value.trim();
-      if (text) morphToText(text);
-    };
-    button?.addEventListener("click", handleClick);
-    const handleKeypress = (e: KeyboardEvent) => {
-      if (e.key === "Enter") handleClick();
-    };
-    input?.addEventListener("keypress", handleKeypress);
-
     return () => {
       window.removeEventListener("resize", handleResize);
-      button?.removeEventListener("click", handleClick);
-      input?.removeEventListener("keypress", handleKeypress);
       renderer.dispose();
       container.removeChild(renderer.domElement);
     };
@@ -281,25 +264,6 @@ export const ContactAnimation = ({ text }: ContactAnimationProps) => {
     }
   }, [text]);
 
-  return (
-    <div ref={containerRef} className="absolute inset-0 -z-10">
-      <div className="absolute bottom-4 left-1/2 flex -translate-x-1/2 gap-2 z-10">
-        <input
-          ref={inputRef}
-          id="morphText"
-          type="text"
-          placeholder="Type text..."
-          className="rounded-md bg-black/50 px-2 py-1 text-white outline-none"
-        />
-        <button
-          ref={buttonRef}
-          id="typeBtn"
-          className="rounded-md bg-purple-600 px-3 py-1 text-white"
-        >
-          Morph
-        </button>
-      </div>
-    </div>
-  );
+  return <div ref={containerRef} className="absolute inset-0 -z-10" />;
 };
 

--- a/components/main/contact-form.tsx
+++ b/components/main/contact-form.tsx
@@ -18,9 +18,10 @@ export const ContactForm = ({ onNameChange }: ContactFormProps) => {
     e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
   ) => {
     setForm({ ...form, [e.target.name]: e.target.value });
-    if (e.target.name === "name" && onNameChange) {
-      onNameChange(e.target.value);
-    }
+  };
+
+  const handleEmailFocus = () => {
+    if (onNameChange) onNameChange(form.name);
   };
 
   const handleSubmit = (e: React.FormEvent) => {
@@ -65,6 +66,7 @@ export const ContactForm = ({ onNameChange }: ContactFormProps) => {
           placeholder="you@example.com"
           value={form.email}
           onChange={handleChange}
+          onFocus={handleEmailFocus}
           required
           className="p-3 rounded-md bg-transparent border border-gray-700 text-white focus:ring-2 focus:ring-purple-500 outline-none"
         />


### PR DESCRIPTION
## Summary
- remove manual text controls from `ContactAnimation`
- trigger morph when focusing the email input
- lay out animation and form side by side on the contact page

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6864ff385bf4832482ce1e3c5b896b0c