### PR TITLE
Improve SEO metadata

### DIFF
--- a/config/index.ts
+++ b/config/index.ts
@@ -1,6 +1,9 @@
 import type { Metadata } from "next";
 
+const metadataBase = new URL("https://dexluna.com");
+
 export const siteConfig: Metadata = {
+  metadataBase,
   title: "DEXLUNA | Softweare Solutions",
   description:
     "Software Solutions for your business, powered by Next.js 14 and React.",
@@ -92,5 +95,32 @@ export const siteConfig: Metadata = {
   authors: {
     name: "FestimBEQIRI",
     url: "https://github.com/festimii",
+  },
+  openGraph: {
+    title: "DEXLUNA | Softweare Solutions",
+    description:
+      "Software Solutions for your business, powered by Next.js 14 and React.",
+    url: "https://dexluna.com",
+    siteName: "DEXLUNA",
+    images: [
+      {
+        url: "/logo1.png",
+        width: 512,
+        height: 512,
+        alt: "DEXLUNA logo",
+      },
+    ],
+    locale: "en_US",
+    type: "website",
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "DEXLUNA | Softweare Solutions",
+    description:
+      "Software Solutions for your business, powered by Next.js 14 and React.",
+    images: ["/logo1.png"],
+  },
+  alternates: {
+    canonical: "/",
   },
 } as const;


### PR DESCRIPTION
## Summary
- add `metadataBase` constant to specify site origin
- include Open Graph, Twitter, and canonical metadata in `siteConfig`

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch font `Inter`)*

------
https://chatgpt.com/codex/tasks/task_e_68652c5679708324bda899c1cdccaf1b