### PR TITLE
Improve skills section with interactive tabs

### DIFF
--- a/components/main/skills.tsx
+++ b/components/main/skills.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { SkillDataProvider } from "@/components/sub/skill-data-provider";
 import { SkillText } from "@/components/sub/skill-text";
 
@@ -9,7 +11,19 @@ import {
   SKILL_DATA,
 } from "@/constants";
 
+import { useState } from "react";
+
+const TABS = [
+  { label: "All", data: SKILL_DATA },
+  { label: "Frontend", data: FRONTEND_SKILL },
+  { label: "Backend", data: BACKEND_SKILL },
+  { label: "Fullstack", data: FULLSTACK_SKILL },
+  { label: "Other", data: OTHER_SKILL },
+] as const;
+
 export const Skills = () => {
+  const [active, setActive] = useState(0);
+
   return (
     <section
       id="skills"
@@ -18,57 +32,24 @@ export const Skills = () => {
     >
       <SkillText />
 
-      <div className="flex flex-row justify-around flex-wrap mt-4 gap-5 items-center">
-        {SKILL_DATA.map((skill, i) => (
-          <SkillDataProvider
-            key={skill.skill_name}
-            src={skill.image}
-            name={skill.skill_name}
-            width={skill.width}
-            height={skill.height}
-            index={i}
-          />
+      <div className="flex gap-4 mt-6">
+        {TABS.map((tab, i) => (
+          <button
+            key={tab.label}
+            onClick={() => setActive(i)}
+            className={`px-3 py-1 rounded border text-sm ${
+              active === i
+                ? "bg-gradient-to-r from-purple-500 to-cyan-500 text-white border-transparent"
+                : "border-[#7042f88b] text-white"
+            }`}
+          >
+            {tab.label}
+          </button>
         ))}
       </div>
 
-      <div className="flex flex-row justify-around flex-wrap mt-4 gap-5 items-center">
-        {FRONTEND_SKILL.map((skill, i) => (
-          <SkillDataProvider
-            key={skill.skill_name}
-            src={skill.image}
-            name={skill.skill_name}
-            width={skill.width}
-            height={skill.height}
-            index={i}
-          />
-        ))}
-      </div>
-      <div className="flex flex-row justify-around flex-wrap mt-4 gap-5 items-center">
-        {BACKEND_SKILL.map((skill, i) => (
-          <SkillDataProvider
-            key={skill.skill_name}
-            src={skill.image}
-            name={skill.skill_name}
-            width={skill.width}
-            height={skill.height}
-            index={i}
-          />
-        ))}
-      </div>
-      <div className="flex flex-row justify-around flex-wrap mt-4 gap-5 items-center">
-        {FULLSTACK_SKILL.map((skill, i) => (
-          <SkillDataProvider
-            key={skill.skill_name}
-            src={skill.image}
-            name={skill.skill_name}
-            width={skill.width}
-            height={skill.height}
-            index={i}
-          />
-        ))}
-      </div>
-      <div className="flex flex-row justify-around flex-wrap mt-4 gap-5 items-center">
-        {OTHER_SKILL.map((skill, i) => (
+      <div className="flex flex-row justify-around flex-wrap mt-8 gap-5 items-center">
+        {TABS[active].data.map((skill, i) => (
           <SkillDataProvider
             key={skill.skill_name}
             src={skill.image}


### PR DESCRIPTION
## Summary
- revamp the skills section to use a tabbed layout
- enable client-side interactivity via `use client`

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch `Inter` font due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6866315a11988324a36738a59b62e190