### PR TITLE
Add project detail pages

### DIFF
--- a/app/projects/[slug]/page.tsx
+++ b/app/projects/[slug]/page.tsx
@@ -1,0 +1,43 @@
+import Image from "next/image";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+
+import { PROJECTS } from "@/constants";
+
+export function generateStaticParams() {
+  return PROJECTS.map((project) => ({ slug: project.slug }));
+}
+
+export default function ProjectPage({ params }: { params: { slug: string } }) {
+  const project = PROJECTS.find((p) => p.slug === params.slug);
+
+  if (!project) {
+    return notFound();
+  }
+
+  return (
+    <main className="flex flex-col items-center py-20 px-4">
+      <h1 className="text-4xl font-semibold text-transparent bg-clip-text bg-gradient-to-r from-purple-500 to-cyan-500">
+        {project.title}
+      </h1>
+      <div className="mt-10 w-full max-w-4xl flex flex-col items-center gap-6">
+        <Image
+          src={project.image}
+          alt={project.title}
+          width={1000}
+          height={1000}
+          className="w-full object-contain rounded-lg"
+        />
+        <p className="text-gray-300 text-center">{project.description}</p>
+        <Link
+          href={project.link}
+          target="_blank"
+          rel="noreferrer noopener"
+          className="py-2 px-4 button-primary text-white rounded-lg"
+        >
+          Visit Site
+        </Link>
+      </div>
+    </main>
+  );
+}

--- a/app/projects/page.tsx
+++ b/app/projects/page.tsx
@@ -1,0 +1,9 @@
+import { Projects } from "@/components/main/projects";
+
+export default function ProjectsPage() {
+  return (
+    <main className="h-full w-full">
+      <Projects />
+    </main>
+  );
+}

--- a/components/main/projects.tsx
+++ b/components/main/projects.tsx
@@ -18,7 +18,7 @@ export const Projects = () => {
             src={project.image}
             title={project.title}
             description={project.description}
-            link={project.link}
+            slug={project.slug}
           />
         ))}
       </div>

--- a/components/sub/project-card.tsx
+++ b/components/sub/project-card.tsx
@@ -5,20 +5,18 @@ type ProjectCardProps = {
   src: string;
   title: string;
   description: string;
-  link: string;
+  slug: string;
 };
 
 export const ProjectCard = ({
   src,
   title,
   description,
-  link,
+  slug,
 }: ProjectCardProps) => {
   return (
     <Link
-      href={link}
-      target="_blank"
-      rel="noreferrer noopener"
+      href={`/projects/${slug}`}
       className="relative overflow-hidden rounded-lg shadow-lg border border-[#2A0E61]"
     >
       <Image

--- a/constants/index.ts
+++ b/constants/index.ts
@@ -260,6 +260,7 @@ export const OTHER_SKILL = [
 export const PROJECTS = [
   {
     title: "QKSS - Map Pin ",
+    slug: "qkss-map-pin",
     description:
       "The QKSS Map Pin platform is a comprehensive monitoring tool designed to track and document events that influence interethnic relations in Kosovo. It serves as a resource to support early warning mechanisms, informed policy analysis, and initiatives aimed at fostering dialogue and building trust among communities.By systematically collecting and mapping incidents and developments, the platform offers real-time insight into dynamics that may impact social cohesion, security, and stability.",
     image: "/projects/project-1.png",
@@ -267,6 +268,7 @@ export const PROJECTS = [
   },
   {
     title: "Interactive Cards Portfolio",
+    slug: "interactive-cards-portfolio",
     description:
       'Step into the extraordinary world of my professional journey through the "Interactive Cards Portfolio" - an innovative and visually captivating platform that redefines the traditional portfolio experience. Ditching the conventional static layout, this portfolio leverages interactive cards to showcase my skills, projects, and personality in an engaging and dynamic manner.',
     image: "/projects/project-2.png",
@@ -274,6 +276,7 @@ export const PROJECTS = [
   },
   {
     title: "Space Themed Website",
+    slug: "space-themed-website",
     description:
       'Embark on an interstellar journey with my "Space Themed Website", a mesmerizing space-themed website that invites you to explore the cosmic wonders beyond our world. Immerse yourself in an awe-inspiring digital experience that blends cutting-edge design with the mysteries of the universe.',
     image: "/projects/project-3.png",


### PR DESCRIPTION
## Summary
- add slug info to projects
- link project cards to internal project pages
- create project details route and index

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch font `Inter` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68663791cf98832490410e1b2719531f