### PR TITLE
Improve mobile experience

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -14,6 +14,8 @@ import "./globals.css";
 const inter = Inter({ subsets: ["latin"] });
 
 export const viewport: Viewport = {
+  width: "device-width",
+  initialScale: 1,
   themeColor: "#030014",
 };
 

--- a/components/main/encryption.tsx
+++ b/components/main/encryption.tsx
@@ -57,7 +57,7 @@ export const Encryption = () => {
           autoPlay
           playsInline
           preload="false"
-          className="w-full h-auto"
+          className="w-full h-[400px] md:h-[600px] object-cover"
         >
           <source src="/videos/encryption-bg.webm" type="video/webm" />
         </video>

--- a/components/main/hero.tsx
+++ b/components/main/hero.tsx
@@ -7,7 +7,7 @@ export const Hero = () => {
         autoPlay
         muted
         loop
-        className="rotate-180 absolute top-[-340px] left-0 w-full h-full object-cover -z-20"
+        className="rotate-180 absolute top-[-340px] left-0 w-full h-full object-cover -z-20 scale-[1.25] md:scale-100"
       >
         <source src="/videos/blackhole.webm" type="video/webm" />
       </video>

--- a/components/main/skills.tsx
+++ b/components/main/skills.tsx
@@ -65,7 +65,7 @@ export const Skills = () => {
       {/* Background Video */}
       <div className="absolute inset-0 z-[-10] opacity-30 pointer-events-none">
         <video
-          className="w-full h-full object-cover"
+          className="w-full h-full object-cover scale-[1.2] md:scale-100"
           preload="false"
           playsInline
           loop

--- a/components/sub/hero-content.tsx
+++ b/components/sub/hero-content.tsx
@@ -15,7 +15,7 @@ export const HeroContent = () => {
     <motion.div
       initial="hidden"
       animate="visible"
-      className="flex flex-row items-center justify-center px-20 mt-40 w-full z-[20]"
+      className="flex flex-col md:flex-row items-center justify-center px-5 md:px-20 mt-20 md:mt-40 w-full z-[20]"
     >
       <div className="h-full w-full flex flex-col gap-5 justify-center m-auto text-start">
         <motion.div
@@ -30,7 +30,7 @@ export const HeroContent = () => {
 
         <motion.div
           variants={slideInFromLeft(0.5)}
-          className="flex flex-col gap-6 mt-6 text-6xl text-bold text-white max-w-[600px] w-auto h-auto"
+          className="flex flex-col gap-6 mt-6 text-4xl md:text-6xl font-bold text-white max-w-[600px] w-auto h-auto"
         >
           <span>
             Providing{" "}
@@ -72,7 +72,7 @@ export const HeroContent = () => {
           height={650}
           width={650}
           draggable={false}
-          className="select-none"
+          className="select-none w-[300px] h-[300px] md:w-[650px] md:h-[650px]"
         />
       </motion.div>
     </motion.div>


### PR DESCRIPTION
## Summary
- expose device-width viewport and initial scale
- tweak hero layout for small screens
- shrink hero font size on smaller devices
- resize hero image responsively
- scale background videos for more visual impact

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch `Inter` font from `fonts.googleapis.com`)*

------
https://chatgpt.com/codex/tasks/task_e_6869a2c6b17083249178a9776f792975